### PR TITLE
Compatibility with Thunderbird 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@
 
 To install this add-on, Please visit the following page.
 
-in progress.
-
 # Requirement
 
 - Tunderbird version 78 or later
@@ -33,6 +31,10 @@ in progress.
 Although it is for OCN, it is not related to OCN. Please do not ask questions to OCN about this plugin.
 
 # History
+
+## v0.6.0
+
+- update for Thunderbird 122
 
 ## v0.5.0
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "applications": {
         "gecko": {
             "id": "kenichi-tanino-Thunderbird-addon-ocnspam@a2.mbn.or.jp",
-            "strict_min_version": "128.0"
+            "strict_min_version": "122.0"
         }
     },
     "name": "SPAM Check for OCN",

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,12 @@
     "applications": {
         "gecko": {
             "id": "kenichi-tanino-Thunderbird-addon-ocnspam@a2.mbn.or.jp",
-            "strict_min_version": "78.0"
+            "strict_min_version": "128.0"
         }
     },
     "name": "SPAM Check for OCN",
     "description": "SPAM Header Checker for OCN(Japanese Internet Provider)",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "author": "Kenichi Tanino",
     "icons": {
         "48": "icons/spam_mail_48x48.png"
@@ -19,6 +19,7 @@
     },
     "permissions": [
         "messagesRead",
+        "messagesUpdate",
         "accountsRead",
         "accountsFolders",
         "storage"


### PR DESCRIPTION
Thunderbird 128 introduced a rare backward incompatibility in its WebExtension API: The method `messages.update()` is now protected by the `messagesUpdate` permission.